### PR TITLE
Simplify testing commands by passing a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,10 +337,12 @@ Normally, the function defined by `defcommand` is passed a number of string argu
 that contains all the parsed and validated values for options and positional arguments (plus a lot of undocumented internal data).
 
 For testing purposes, you can bypass the parsing and validation, and just pass a single map to the function. 
+The map must provide a keyword key for each option or positional argument; the keys match the option or argument symbols,
+even for options that normally have a default value. All normal option or argument validation is skipped.
 
 You may need to mock out `net.lewisship.cli-tools/print-summary` if your command
 invokes it, as that relies on some additional non-documented keys to
-be present in the command map.
+be present in the command map. Fortunately, it is quite rare for a command to need to invoke this function.
 
 When _not_ bypassing parsing and validation (that is, when testing by passing strings to the command function), 
 validation errors normally print a command summary and then call `net.lewisship.cli-tools/exit`, which in turn, invokes `System/exit`; this is obviously 

--- a/README.md
+++ b/README.md
@@ -278,12 +278,12 @@ option-like string that isn't declared.
 You might expect that `app-admin remote ls -lR` would work, but it will fail
 with an error that `-lR is not recognized`.
 
-You can always use `--` to split options from arguments, so `bb remote -- ls -lR` will work,
+You can always use `--` to split options from arguments, so `app-admin remote -- ls -lR` will work,
 but is clumsy.
 
 Instead, add `:in-order true` to the end of the interface, and any
 unrecognized options will be parsed as positional arguments instead,
-so `bb remote ls -lR` will work, and `-lR` will be provided as a string in the `args`
+so `app-admin remote ls -lR` will work, and `-lR` will be provided as a string in the `args`
 seq.
 
 ### :let \<bindings\>
@@ -334,24 +334,20 @@ local symbols (such as `alpha` and `numeric`) and not functions that are passed 
 
 Normally, the function defined by `defcommand` is passed a number of string arguments, from
 `*command-line-args*`; it then parses this into a command map, a map with an `:options` key
-(plus a lot of undocumented internal data).
+that contains all the parsed and validated values for options and positional arguments (plus a lot of undocumented internal data).
 
-For testing purposes, you can bypass the parsing, and just pass a single map to the function, with
-a nested `:options` key.
+For testing purposes, you can bypass the parsing and validation, and just pass a single map to the function. 
 
 You may need to mock out `net.lewisship.cli-tools/print-summary` if your command
 invokes it, as that relies on some additional non-documented keys to
 be present in the command map.
 
-Finally, validation errors normally print a command summary and then
-call `net.lewisship.cli-tools/exit`, which in turn, invokes `System/exit`; this is obviously 
+When _not_ bypassing parsing and validation (that is, when testing by passing strings to the command function), 
+validation errors normally print a command summary and then call `net.lewisship.cli-tools/exit`, which in turn, invokes `System/exit`; this is obviously 
 problematic for tests.
 
 The function `net.lewisship.cli-tools/set-prevent-exit!` can convert those cases to instead
 throw an exception, which can be caught by tests.
-
-When passing a map to a command function, the validations (defined by the `:validate` directive)
-are bypassed.
 
 Further, application code should also invoke `net.lewisship.cli-tools/exit`
 rather than `System/exit`, for the same reason.

--- a/src/net/lewisship/cli_tools.clj
+++ b/src/net/lewisship/cli_tools.clj
@@ -121,7 +121,7 @@
              ;; it can also be a map with key :options
              test-mode?# (impl/command-map? args#)
              ~command-map-symbol (if test-mode?#
-                                   (first args#)
+                                   {:options (first args#)}
                                    (impl/parse-cli ~command-name'
                                                    args#
                                                    ~(select-keys parsed-interface parse-cli-keys)))

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -170,15 +170,25 @@
    n ["-n" "--numeric N"]
    :validate [(some? a) "--alpha is required"
               (some? n) "--numeric is required"
-              (not (and a n)) "--alpha and --numeric are exclusive"]])
+              (not (and a n)) "--alpha and --numeric are exclusive"]]
+  {:alpha a
+   :numeric n})
 
 (deftest validate-directive
 
   (with-exit-errors ["--numeric is required"]
-                    (validate "-a" "alpha" ))
+                    (validate "-a" "alpha"))
 
   (with-exit-errors ["--alpha and --numeric are exclusive"]
                     (validate "-a" "alpha" "-n" "123")))
+
+(deftest map-bypasses-validations
+  (is (= {:mode ::unexpected}
+         (set-mode {:mode ::unexpected})))
+
+  (is (= {:alpha   true
+          :numeric true}
+         (validate {:a true :n true}))))
 
 
 ;; This test fails under Babashka (repl/doc returns empty string) and not sure why.

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -165,7 +165,7 @@
                     (set-mode "-m" "unknown")))))
 
 (defcommand validate
-  ""
+  "validate command"
   [a ["-a" "--alpha S"]
    n ["-n" "--numeric N"]
    :validate [(some? a) "--alpha is required"


### PR DESCRIPTION
Previously, command could be tested by passing a map with an `:options` key whose value was a map of option and argument values.  This change simplifies it, by passing _only_ the inner map (of argument values).