### PR TITLE
Support command groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@ Testing was simplified; command functions can be tested by passing them a single
 argument values (previously values map was nested in another map).
 
 Namespaces now represent _categories_ of related commands; this changes the output from the `help` command.
-
+Further, categories may also be command groups, which applies a prefix to all commands within the category
+(this is useful with tools that define large numbers of subcommands).
+ 
 [Closed Issues](https://github.com/hlship/cli-tools/issues?q=is%3Aclosed+milestone%3A0.9)
 
 # 0.8 -- 5 Jul 2023

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ At the core, you define local symbols and instructions for how those symbols map
 or positional arguments; `cli-tools` takes care of the majority of command line parsing and validation
 for you.
 
-`cli-tools` is generally used to create tools that contain individual commands; each of these commands
-has its own unique options and arguments; `cli-tools` identifies the command from the first command line
-argument, then passes the remaining arguments to the selected command.  In this case,
-a built-in `help` command lists out what commands are available.
+`cli-tools` is intended to create three types of command lines tools:
+ 
+- A simple tool simply parses its command line arguments and executes some code using those arguments (think: `ls` or `cat`)
+- A proper tool is composed of multiple commands, across multiple namespaces. The first command line argument
+  will select the specific sub-command to execute. (think: `git`)
+- A complex tool organizes some commands into command groups which share an initial name (think: `k8s`)
 
-`cli-tools` can be used for tools that simply have options and arguments but not commands.  
-It isn't intended for tools that have more deeply nested levels of sub-commands.
+For tools with multiple commands, `cli-tools` automatically adds 
+a built-in `help` command to list out what commands are available.
 
 `cli-tools` can work with Babashka, or with Clojure, but the near instantaneous startup time of Babashka is compelling
 for the kind of low-ceremony tools that `cli-tools` is intended for.
@@ -367,6 +369,16 @@ a sort order of 100, so that it will generally be last.
 If you want to see the list of commands without categories, use the `-f` / `--flat` option to `help`.
 If you want to use multiple namespaces for your commands without using categories,
 add the `:flat` option to the map passed to `dispatch`.
+
+## Command Groups
+
+A category can also have a `:command-group` metadata value, a short string that acts like a command name.
+All commands in the same namespace/category are accessible via that group command.  The built-in `help`
+command will identify the command group when listing the commands in the category.
+
+Command groups are useful for the largest tools with the most commands; it allows for shorter command names,
+as the name only have to be unique within command group, not globally.
+
 
 ## Testing
 

--- a/scale-test/templates/command-ns.edn
+++ b/scale-test/templates/command-ns.edn
@@ -1,5 +1,9 @@
 (ns {{ns}}
   "Command group {{ns}}"
+  {:command-category "{{category}}"
+{% if group %}
+   :command-group "{{group}}"
+{% endif %}}
   (:require [net.lewisship.cli-tools :refer [defcommand]]))
 
 {% for command-name in command-names %}

--- a/src/net/lewisship/cli_tools.clj
+++ b/src/net/lewisship/cli_tools.clj
@@ -178,8 +178,7 @@
                                         ;; within a group. This is the first place that would change if we allowed groups
                                         ;; within groups.
                                         (assoc m command-group {:command-path   [command-group]
-                                                                :group-category category-map
-                                                                :sub-commands   []})))
+                                                                :group-category category-map})))
                                     {}))
         f              (fn [m category-map]
                          (let [{:keys [category command-group ns]} category-map
@@ -211,14 +210,10 @@
                                                                                   (source-of v)
                                                                                   where))))
                                               :else
-                                              (cond-> (assoc-in m command-path {:category     category
-                                                                                :command-name command-name ; name within group
-                                                                                :command-path command-path ; needed?
-                                                                                :var          v})
-                                                      ;; When there's a command-group, the base-path identifies the psuedo-command
-                                                      ;; for the containing group. We need to identify this new command as a sub-command
-                                                      ;; in the group.
-                                                      command-group (update-in base-path update :sub-commands conj command-name)))))
+                                              (assoc-in m command-path {:category     category
+                                                                        :command-name command-name ; name within group
+                                                                        :command-path command-path
+                                                                        :var          v}))))
                                         m))))
         commands       (reduce f group-commands categories)]
     [categories commands]))
@@ -234,8 +229,8 @@
   - :tool-name - used in command summary and errors
   - :tool-doc - used in command summary
   - :arguments - seq of strings; first is name of command, rest passed to command
-  - :categories - seq of maps describing the command categories
-  - :commands - set of command maps (see [[locate-commands]])
+  - :categories - seq of maps describing the command categories (see [[locate-commands]])
+  - :commands - seq of command maps (see [[locate-commands]])
 
   Each namespace forms a command category, represented as a map with keys:
   - :category - symbol identifying the namespace

--- a/src/net/lewisship/cli_tools.clj
+++ b/src/net/lewisship/cli_tools.clj
@@ -3,7 +3,7 @@
   {:command-category       "Built-in"
    :command-category-order 100}
   (:require [clojure.spec.alpha :as s]
-            [net.lewisship.cli-tools.impl :as impl]
+            [net.lewisship.cli-tools.impl :as impl :refer [cond-let]]
             [clojure.string :as str]))
 
 (defn exit
@@ -93,7 +93,7 @@
   (assert (simple-symbol? command-name)
           "defcommand expects a symbol for command name")
   (assert (string? docstring)
-          (throw "defcommand requires a docstring"))
+          "defcommand requires a docstring")
   (assert (vector? interface)
           "defcommand expects a vector to define the interface")
   (let [symbol-meta (meta command-name)
@@ -149,37 +149,79 @@
     ns-object
     (throw (RuntimeException. (format "namespace %s not found (it may need to be required)" (name ns-symbol))))))
 
+(defn- namespace->category
+  [ns-symbol]
+  (let [ns      (resolve-ns ns-symbol)
+        ns-meta (meta ns)]
+    {:category      ns-symbol
+     :ns            ns
+     :command-group (:command-group ns-meta)
+     :label         (:command-category ns-meta (name ns-symbol))
+     :order         (:command-category-order ns-meta 0)}))
+
 (defn locate-commands
   "Passed a seq of symbols identifying *loaded* namespaces, this function
   locates commands, functions defined by [[defcommand]].
 
   Normally, this is called from [[dispatch]] and is only needed when calling [[dispatch*]] directly.
 
-  Returns a map from string command name to a map of :category (the namespace symbol)
-  and :var (the Var containing the command function)."
+  Returns a tuple: the command categories map, and the command map."
   [namespace-symbols]
-  (let [f (fn [m namespace-symbol]
-            (->> (resolve-ns namespace-symbol)
-                 ns-publics
-                 vals
-                 (reduce (fn [m v]
-                           (let [command-name (-> v meta ::impl/command-name)]
-                             (cond
-                               (nil? command-name)
-                               m
+  (let [categories     (map namespace->category namespace-symbols)
+        ;; Each category that is a command group gets a psuedo command
+        group-commands (->> categories
+                            (filter :command-group)
+                            (reduce (fn [m category-map]
+                                      (let [{:keys [command-group]} category-map]
+                                        ;; TODO: Check for conflicts
+                                        ;; Currently, we only allow two levels of nesting: top level, and directly
+                                        ;; within a group. This is the first place that would change if we allowed groups
+                                        ;; within groups.
+                                        (assoc m command-group {:command-path   [command-group]
+                                                                :group-category category-map
+                                                                :sub-commands   []})))
+                                    {}))
+        f              (fn [m category-map]
+                         (let [{:keys [category command-group ns]} category-map
+                               base-path (cond-> []
+                                                 command-group (conj command-group))]
+                           (->> ns
+                                ns-publics
+                                ;; Iterate over the public vars of the namespace
+                                vals
+                                (reduce (fn [m v]
+                                          (let [command-name (-> v meta ::impl/command-name)]
+                                            (cond-let
+                                              :let [command-name (-> v meta ::impl/command-name)]
 
-                               (contains? m command-name)
-                               (throw (RuntimeException. (format "command %s defined by %s conflicts with %s"
-                                                                 command-name
-                                                                 (source-of v)
-                                                                 (source-of (get-in m [command-name :var])))))
+                                              ;; Not a defcommand?
+                                              (nil? command-name)
+                                              m
 
-                               :else
-                               (assoc m command-name {:category     namespace-symbol
-                                                      :command-name command-name
-                                                      :var          v}))))
-                         m)))]
-    (reduce f {} namespace-symbols)))
+                                              :let [command-path (conj base-path command-name)
+                                                    conflict (get-in m command-path)]
+
+                                              conflict
+                                              (let [command-var (:var conflict)
+                                                    where       (if command-var
+                                                                  (source-of command-var)
+                                                                  (str "namespace " (name (get-in conflict [:group-category :category]))))]
+                                                (throw (RuntimeException. (format "command %s defined by %s conflicts with %s"
+                                                                                  (str/join " " command-path)
+                                                                                  (source-of v)
+                                                                                  where))))
+                                              :else
+                                              (cond-> (assoc-in m command-path {:category     category
+                                                                                :command-name command-name ; name within group
+                                                                                :command-path command-path ; needed?
+                                                                                :var          v})
+                                                      ;; When there's a command-group, the base-path identifies the psuedo-command
+                                                      ;; for the containing group. We need to identify this new command as a sub-command
+                                                      ;; in the group.
+                                                      command-group (update-in base-path update :sub-commands conj command-name)))))
+                                        m))))
+        commands       (reduce f group-commands categories)]
+    [categories commands]))
 
 (defn dispatch*
   "Invoked by [[dispatch]] after namespace and command resolution.
@@ -193,12 +235,13 @@
   - :tool-doc - used in command summary
   - :arguments - seq of strings; first is name of command, rest passed to command
   - :categories - seq of maps describing the command categories
-  - :commands - map from string command name to a map of var and command category (see [[locate-commands]])
+  - :commands - set of command maps (see [[locate-commands]])
 
   Each namespace forms a command category, represented as a map with keys:
   - :category - symbol identifying the namespace
+  - :command-group string - optional, from :command-group metadata on namespace, groups commands with a prefix name
   - :label - string (from :command-category metadata on namespace), defaults to the namespace name
-  - :order - number (from :command-category-order metadata), defaults to 0
+  - :order - number (from :command-category-order metadata on namespace), defaults to 0
 
   In the `help` command summary, the categories are sorted into ascending order by :order,
   then by :label. Individual commands are listed under each category, in ascending alphabetic order.
@@ -209,32 +252,19 @@
   [options]
   (impl/dispatch options))
 
-(defn- namespace->category
-  [ns-symbol]
-  (let [ns-meta (-> ns-symbol find-ns meta)]
-    {:category ns-symbol
-     :label    (:command-category ns-meta (name ns-symbol))
-     :order    (:command-category-order ns-meta 0)}))
-
 (defn expand-dispatch-options
   "Called by [[dispatch]] to expand the options before calling [[dispatch*]].
   Some applications may call this instead of `dispatch`, modify the results, and then
   invoke `dispatch*`."
   [options]
   (let [{:keys [namespaces arguments tool-name tool-doc flat]} options
-        tool-name'         (or tool-name
-                               (impl/default-tool-name)
-                               (throw (ex-info "No :tool-name specified" {:options options})))
-        _                  (when-not (seq namespaces)
-                             (throw (ex-info "No :namespaces specified" {:options options})))
-        ;; Add this namespace, to include the help command by default
-        all-namespaces     (cons 'net.lewisship.cli-tools namespaces)
-        commands           (do
-                             ;; Load all the other namespaces first
-                             (run! require namespaces)
-                             ;; Ensure built-in help command is first
-                             (locate-commands all-namespaces))
-        command-categories (map namespace->category all-namespaces)]
+        tool-name' (or tool-name
+                       (impl/default-tool-name)
+                       (throw (ex-info "No :tool-name specified" {:options options})))
+        _          (when-not (seq namespaces)
+                     (throw (ex-info "No :namespaces specified" {:options options})))
+        _          (run! require namespaces)
+        [command-categories commands] (locate-commands (cons 'net.lewisship.cli-tools namespaces))]
     {:tool-name  tool-name'
      :tool-doc   (or tool-doc
                      (some-> namespaces first find-ns meta :doc))

--- a/src/net/lewisship/cli_tools/impl.clj
+++ b/src/net/lewisship/cli_tools/impl.clj
@@ -392,8 +392,8 @@
                  (assoc state' :specs more-specs)))))))
 
 (defn abort
-  [s]
-  (println-err s)
+  [& compose-inputs]
+  (println-err (apply compose compose-inputs))
   (exit 1))
 
 (defn- fail
@@ -743,7 +743,7 @@
 
       (or (nil? command-name)
           (str/starts-with? command-name "-"))
-      (abort (compose [:bold tool-name] ": no command provided" (use-help-message tool-name help-command)))
+      (abort [:bold tool-name] ": no command provided" (use-help-message tool-name help-command))
 
       :else
       (loop [prefix            []
@@ -752,12 +752,11 @@
              possible-commands commands]
         (cond-let
           (nil? term)
-          (abort (compose [:bold tool-name]
-                          ": "
-                          [:yellow (str/join " " prefix)]
-                          " is incomplete, a sub-command name should follow"
-                          ;; TODO: Get the list of sub-commands?
-                          (use-help-message tool-name help-command)))
+          (abort [:bold tool-name]
+                 ": "
+                 [:yellow (str/join " " prefix)]
+                 " is incomplete, a sub-command name should follow"
+                 (use-help-message tool-name help-command))
 
           ;; In a command group, only the string keys map to further commands; keyword keys are other structure.
           :let [matchable-terms (filter string? (keys possible-commands))
@@ -781,10 +780,12 @@
                                 [:bold tool-name " help"]
                                 " to list commands"))]
             (abort
-              (compose
-                [:bold tool-name ": " [:red
-                                       (string/join " " (conj prefix term))]] " "
-                body suffix help-suffix)))
+              [:bold tool-name ": " [:red
+                                     (string/join " " (conj prefix term))]]
+              " "
+              body
+              suffix
+              help-suffix))
 
           :let [matched-term (first matched-terms)
                 matched-command (get possible-commands matched-term)]

--- a/test-resources/tool-help-grouped-flat.txt
+++ b/test-resources/tool-help-grouped-flat.txt
@@ -1,0 +1,10 @@
+Usage: [1mgroup-test[22m COMMAND ...[m
+
+Group example namespace
+
+Commands:
+     [32;1mdefault[39;22m: Default command summary[m
+    [32;1mexplicit[39;22m: Explicit command summary[m
+  [32;1mgroup echo[39;22m: Echo a string[m
+  [32;1mgroup edit[39;22m: Edit a whatever[m
+        [32;1mhelp[39;22m: List available commands[m

--- a/test-resources/tool-help-grouped.txt
+++ b/test-resources/tool-help-grouped.txt
@@ -1,0 +1,16 @@
+Usage: [1mgroup-test[22m COMMAND ...[m
+
+Group example namespace
+
+Commands:
+
+[32;1mgroup[39m - Grouped commands[m
+      [32;1mecho[39;22m: Echo a string[m
+      [32;1medit[39;22m: Edit a whatever[m
+
+[1mnet.lewisship.example-ns[m
+   [32;1mdefault[39;22m: Default command summary[m
+  [32;1mexplicit[39;22m: Explicit command summary[m
+
+[1mBuilt-in[m
+      [32;1mhelp[39;22m: List available commands[m

--- a/test/net/lewisship/cli_tools/impl_test.clj
+++ b/test/net/lewisship/cli_tools/impl_test.clj
@@ -160,7 +160,8 @@
 
 (deftest command-not-provided
   (let [*message* (atom nil)]
-    (with-redefs [impl/abort #(reset! *message* %)]
+    (with-redefs [impl/abort (fn [& inputs]
+                               (reset! *message* (apply ansi/compose inputs)))]
       (impl/dispatch {:tool-name "loco"
                       :commands  {"help" {:var ::placeholder}}
                       :arguments ["-no-such-option"]})

--- a/test/net/lewisship/cli_tools/impl_test.clj
+++ b/test/net/lewisship/cli_tools/impl_test.clj
@@ -142,19 +142,18 @@
              "this-tool"
              " help"]
             " to list commands")
-        (impl/use-help-message "this-tool" {"help"         nil
-                                            "some-command" nil})))
+        (impl/use-help-message "this-tool" true)))
   (is (= nil
-         (impl/use-help-message "this-tool" {"some-command" nil}))))
+         (impl/use-help-message "this-tool" nil))))
 
 (deftest provides-help-with-h-or-help
   (let [*help-args* (atom nil)
-        commands    {"help" {:var #(reset! *help-args* %)}}
+        commands    {"help" {:var (fn [& args] (reset! *help-args* args))}}
         options     {:tool-name "test-tool"
                      :commands  commands}]
     (doseq [arg ["-h" "--help"]
             :let [extra-arg (str "extra" arg)]]
-      (reset! *help-args* nil)
+      (reset! *help-args* ::unset)
       (impl/dispatch (assoc options :arguments [arg extra-arg]))
       (is (= [extra-arg]
              @*help-args*)))))
@@ -163,15 +162,15 @@
   (let [*message* (atom nil)]
     (with-redefs [impl/abort #(reset! *message* %)]
       (impl/dispatch {:tool-name "loco"
-                      :commands  {"help" nil}
-                      :arguments ["-not-such-option"]})
+                      :commands  {"help" {:var ::placeholder}}
+                      :arguments ["-no-such-option"]})
       (is (= "loco: no command provided, use loco help to list commands"
              @*message*))
 
       (reset! *message* nil)
 
       (impl/dispatch {:tool-name "bravo"
-                      :commands  {"help" nil}
+                      :commands  {"help" {:var ::placeholder}}
                       :arguments ["no-such-command"]})
 
       (is (= "bravo: no-such-command is not a command, use bravo help to list commands"

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -265,8 +265,7 @@
                                        :command-group "group"
                                        :label         "Grouped commands"
                                        :ns            group-ns
-                                       :order         0}
-                      :sub-commands   ["edit" "echo"]}
+                                       :order         0}}
              "help"  {:category     'net.lewisship.cli-tools
                       :command-name "help"
                       :command-path ["help"]
@@ -302,7 +301,7 @@
 
 (defmacro with-abort
   [& body]
-  `(with-redefs [impl/abort #(throw (Exception. %))]
+  `(with-redefs [impl/abort (fn [& inputs#] (throw (Exception. (apply ansi/compose inputs#))))]
      (binding [ansi/*color-enabled* false]
        (when-let [e# (is (~'thrown? Exception (do ~@body)))]
          (ex-message e#)))))

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -1,6 +1,9 @@
 (ns net.lewisship.cli-tools-test
-  (:require [clojure.test :refer [deftest is use-fixtures are]]
+  (:require [clj-commons.ansi :as ansi]
+            [clojure.test :refer [deftest is use-fixtures are]]
             [net.lewisship.cli-tools :as cli :refer [defcommand dispatch]]
+            net.lewisship.group-ns
+            net.lewisship.conflict
             [net.lewisship.cli-tools.impl :as impl]
             [clojure.repl :as repl]
             [clojure.string :as str]))
@@ -75,25 +78,32 @@
   (with-exit 999
              (cli/exit 999)))
 
+
+(defn invoke-command
+  [& args]
+  (dispatch {:tool-name "harness"
+             :namespaces ['net.lewisship.cli-tools-test]
+             :arguments args}))
+
 (deftest standard-help
   (is (= (slurp "test-resources/help.txt")
-         (with-exit 0 (configure "-h")))))
+         (with-exit 0 (invoke-command "configure" "-h")))))
 
 (deftest unknown-option
   (is (= (slurp "test-resources/unknown-option.txt")
-         (with-exit 1 (configure "--debug")))))
+         (with-exit 1 (invoke-command "configure" "--debug")))))
 
 (deftest pos-arg-validation-failure
   (is (= (slurp "test-resources/pos-arg-validation-failure.txt")
-         (with-exit 1 (configure "myhost.com" "fred=flinstone")))))
+         (with-exit 1 (invoke-command "configure" "myhost.com" "fred=flinstone")))))
 
 (deftest insuffient-values
   (is (= (slurp "test-resources/insufficient-values.txt")
-         (with-exit 1 (collect "just-key")))))
+         (with-exit 1 (invoke-command "collect" "just-key")))))
 
 (deftest excess-values
   (is (= (slurp "test-resources/excess-values.txt")
-         (with-exit 1 (collect "the-key" "the-value" "the-extra")))))
+         (with-exit 1 (invoke-command "collect" "the-key" "the-value" "the-extra")))))
 
 
 (defcommand default-variants
@@ -105,7 +115,7 @@
 
 (deftest option-defaults
   (is (= (slurp "test-resources/option-defaults.txt")
-        (with-exit 0 (default-variants "-h")))))
+        (with-exit 0 (invoke-command "default-variants" "-h")))))
 
 (defcommand in-order
   ""
@@ -125,15 +135,11 @@
          ;; Without :in-order true, the -lR is flagged as an error
          (in-order "-v" "ls" "-lR"))))
 
-(defcommand help
-           "Conflicts with built-in help"
-  [])
-
 (deftest detects-command-name-conflicts
   (when-let [e (is (thrown? RuntimeException
                             (cli/locate-commands ['net.lewisship.cli-tools
-                                                  'net.lewisship.cli-tools-test])))]
-    (is (= "command help defined by net.lewisship.cli-tools-test/help conflicts with net.lewisship.cli-tools/help"
+                                                  'net.lewisship.conflict])))]
+    (is (= "command help defined by net.lewisship.conflict/help conflicts with net.lewisship.cli-tools/help"
            (ex-message e)))))
 
 (deftest rejects-undefined-namespace
@@ -169,7 +175,7 @@
 (deftest let-directive
   (is (= (slurp "test-resources/let-directive.txt")
          (with-exit 1
-                    (set-mode "-m" "unknown")))))
+                    (invoke-command "set-mode" "-m" "unknown")))))
 
 (defcommand validate
   "validate command"
@@ -231,3 +237,79 @@
 (deftest sorted-name-list
   (is (= "foxtrot, tango, whiskey"
          (cli/sorted-name-list [:whiskey :tango :foxtrot]))))
+
+(deftest group-namespace
+  (let [group-ns (find-ns 'net.lewisship.group-ns)
+        cli-ns   (find-ns 'net.lewisship.cli-tools)]
+    (is (= [[{:category      'net.lewisship.group-ns
+              :command-group "group"
+              :label         "Grouped commands"
+              :ns            group-ns
+              :order         0}
+             {:category      'net.lewisship.cli-tools
+              :command-group nil
+              :label         "Built-in"
+              :ns            cli-ns
+              :order         100}]
+            {"group" {"echo"          {:category     'net.lewisship.group-ns
+                                       :command-name "echo"
+                                       :command-path ["group" "echo"]
+                                       :var          #'net.lewisship.group-ns/echo}
+                      "edit"          {:category     'net.lewisship.group-ns
+                                       :command-name "edit"
+                                       :command-path ["group"
+                                                      "edit"]
+                                       :var          #'net.lewisship.group-ns/edit}
+                      :command-path   ["group"]
+                      :group-category {:category      'net.lewisship.group-ns
+                                       :command-group "group"
+                                       :label         "Grouped commands"
+                                       :ns            group-ns
+                                       :order         0}
+                      :sub-commands   ["edit" "echo"]}
+             "help"  {:category     'net.lewisship.cli-tools
+                      :command-name "help"
+                      :command-path ["help"]
+                      :var          #'net.lewisship.cli-tools/help}}]
+           (cli/locate-commands '[net.lewisship.group-ns
+                                  net.lewisship.cli-tools])))))
+
+(defn exec-group [& args]
+  (dispatch {:tool-name  "group-test"
+             :namespaces '[net.lewisship.group-ns
+                           net.lewisship.example-ns]
+             :arguments  args}))
+
+(deftest help-with-default-and-explicit-summary-grouped
+  (is (= (slurp "test-resources/tool-help-grouped.txt")
+         (with-exit 0
+                    (exec-group "help")))))
+
+(deftest help-with-default-and-explicit-summary-flat-grouped
+  (is (= (slurp "test-resources/tool-help-grouped-flat.txt")
+         (with-exit 0
+                    (exec-group "help" "-f")))))
+
+(deftest can-find-a-grouped-command
+  (is (= "echo: fancy\n"
+         (with-out-str
+           (exec-group "group" "echo" "fancy")))))
+
+(deftest can-use-group-abbreviations
+  (is (= "echo: abbreviated\n"
+         (with-out-str
+           (exec-group "g" "ec" "abbreviated")))))
+
+(defmacro with-abort
+  [& body]
+  `(with-redefs [impl/abort #(throw (Exception. %))]
+     (binding [ansi/*color-enabled* false]
+       (when-let [e# (is (~'thrown? Exception (do ~@body)))]
+         (ex-message e#)))))
+
+(deftest reports-group-match-failure
+  (is (= "group-test: g e matches 2 possible commands, use group-test help to list commands"
+         (with-abort (exec-group "g" "e" "multiple"))))
+
+  (is (= "group-test: echo is not a command, use group-test help to list commands"
+         (with-abort (exec-group "echo" "wrong-level")))))

--- a/test/net/lewisship/conflict.clj
+++ b/test/net/lewisship/conflict.clj
@@ -1,0 +1,6 @@
+(ns net.lewisship.conflict
+  (:require [net.lewisship.cli-tools :refer [defcommand]]))
+
+(defcommand help
+  "Conflicts with built-in help"
+  [])

--- a/test/net/lewisship/group_ns.clj
+++ b/test/net/lewisship/group_ns.clj
@@ -1,0 +1,15 @@
+(ns net.lewisship.group-ns
+  "Group example namespace"
+  {:command-group "group"
+   :command-category "Grouped commands"}
+  (:require [net.lewisship.cli-tools :refer [defcommand]]))
+
+(defcommand echo
+  "Echo a string"
+  [:args
+   s ["TEXT" "Text to echo"]]
+  (println "echo:" s))
+
+(defcommand edit
+  "Edit a whatever"
+  [])


### PR DESCRIPTION
The extends namespace-based categories such that some categories are a command group, establishing a prefix command for the commands within the namespace. This is useful in the largest tools with (perhaps) hundreds of commands, as it allows individual commands to have shorter names, qualified by the command group.

Currently, only supports two levels (top level, like `help`), or in a command group), but this might be extended in the future to allow command groups themselves to nest.