### PR TITLE
Improve output when a command name is ambiguous

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,13 @@
 Added new function `select-option`, used to build the option spec for an option
 selected from a list of possible values.
 
+Improved the output of command mis-matches (where the input is not sufficient to
+uniquely identify a command), and removed the fuzzy match ("did you mean?")
+that did not seem to provide any real benefit.
+
+[Closed Issues](https://github.com/hlship/cli-tools/issues?q=is%3Aclosed+milestone%3A0.10)
+
+
 # 0.9 -- 11 Sep 2023
 
 Testing was simplified; command functions can be tested by passing them a single map of option and

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src"]
  ;; Needed to build and test w/ clojure
- :deps  {org.clojure/tools.cli  {:mvn/version "1.0.219"}
-         org.clj-commons/pretty {:mvn/version "2.2"}
-         clj-fuzzy/clj-fuzzy    {:mvn/version "0.4.1"}}
+ :deps  {org.clojure/tools.cli    {:mvn/version "1.0.219"}
+         org.clj-commons/pretty   {:mvn/version "2.2"}
+         org.clj-commons/humanize {:mvn/version "1.0"}}
 
  :net.lewisship.build/scm
  {:url "https://github.com/hlship/cli-tools"}
@@ -15,7 +15,7 @@
    :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1"
                                                        :git/sha "dfb30dd"}}
    :exec-fn     cognitect.test-runner.api/test
-   :jvm-opts ["-Dclj-commons.ansi.enabled=true"]
+   :jvm-opts    ["-Dclj-commons.ansi.enabled=true"]
    :exec-args
    {:patterns [".*-tests?$"]}}
 

--- a/test/net/lewisship/cli_tools/impl_test.clj
+++ b/test/net/lewisship/cli_tools/impl_test.clj
@@ -1,5 +1,5 @@
 (ns net.lewisship.cli-tools.impl-test
-  (:require [clojure.test :refer [deftest is use-fixtures]]
+  (:require [clojure.test :refer [deftest is are use-fixtures]]
             [clj-commons.ansi :as ansi]
             [net.lewisship.cli-tools.impl :refer [compile-interface]]
             [net.lewisship.cli-tools.impl :as impl]))
@@ -174,5 +174,52 @@
                       :commands  {"help" {:var ::placeholder}}
                       :arguments ["no-such-command"]})
 
-      (is (= "bravo: no-such-command is not a command, use bravo help to list commands"
+      (is (= "bravo: no-such-command is not a command; use bravo help to list commands"
              @*message*)))))
+
+(deftest compose-list-tests
+  (let [base-terms ["alpha" "bravo" "charlie" "delta" "echo" "foxtrot"]]
+    (are [terms opts expected]
+      (= expected
+         (impl/compose-list terms opts))
+
+      base-terms
+      nil
+      '([:green "alpha"] ", "
+        [:green "bravo"] ", "
+        [:green "charlie"] ", and three other commands")
+
+      nil
+      nil
+      nil
+
+      (take 1 base-terms)
+      nil
+      [:green "alpha"]
+
+      (take 2 base-terms)
+      nil
+      '([:green "alpha"] " and "
+        [:green "bravo"])
+
+      (take 3 base-terms)
+      nil
+      '([:green "alpha"] ", "
+        [:green "bravo"] ", and "
+        [:green "charlie"])
+
+      base-terms
+      {:max-terms  1
+       :noun       "thing"
+       :conjuction "or"
+       :font       :cyan}
+      '([:cyan "alpha"]
+        " or five other things")
+
+      (take 4 base-terms)
+      {:noun       "thing"
+       :conjuction "or"
+       :font       :cyan}
+      '([:cyan "alpha"] ", "
+        [:cyan "bravo"] ", "
+        [:cyan "charlie"] ", or one other thing"))))

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -307,10 +307,10 @@
          (ex-message e#)))))
 
 (deftest reports-group-match-failure
-  (is (= "group-test: g e matches 2 possible commands, use group-test help to list commands"
+  (is (= "group-test: g e matches echo and edit; use group-test help to list commands"
          (with-abort (exec-group "g" "e" "multiple"))))
 
-  (is (= "group-test: echo is not a command, use group-test help to list commands"
+  (is (= "group-test: echo is not a command; use group-test help to list commands"
          (with-abort (exec-group "echo" "wrong-level")))))
 
 (deftest select-option-no-default


### PR DESCRIPTION
<img width="1095" alt="image" src="https://github.com/hlship/cli-tools/assets/52660/7f7a5002-6237-4391-86f6-01575a0319b2">
