### PR TITLE
Setup linting with clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:config-paths ["../resources/clj-kondo.exports/io.github.hlship/cli-tools"]
+ :output       {:linter-name true}}

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -38,9 +38,14 @@ jobs:
           # List all files containing dependencies:
           key: cljdeps-${{ hashFiles('deps.edn') }}
 
-      - name: Run tests
+      - name: Run tests (default, Clojure 1.12)
         run: clojure -X:test
 
+      - name: Run tests (Clojure 1.11)
+        run: clojure -X:1.11:test
+
+      - name: Lint
+        run: clojure -M:lint
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /target/
 *.asc
+.idea
+.cpcache
+.clj-kondo/.cache
+.nrepl-port
+*.iml

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ for you.
   will select the specific sub-command to execute. (think: `git`)
 - A complex tool organizes some commands into command groups that share an initial name (think `kubectl`)
 
-
 For tools with multiple commands, `cli-tools` automatically adds 
 a built-in `help` command to list out what commands are available, and
 can even perform basic searches for commands.
@@ -47,6 +46,10 @@ Below is an example of the author's personal toolkit, `flow`:
 
 A complete and open-source example is [dialog-tool](https://github.com/hlship/dialog-tool), which also shows how to organize 
 a tool so that it can be installed as a Homebrew formula.
+
+## Compatibility
+
+`cli-tools` is compatible with Clojure 1.11 and above, and w/ Babashka.
 
 ## defcommand
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,13 @@ zsh completions greatly enhance the discoverability of commands, categories, and
 However, this functionality is considered _experimental_ due to the complexity of zsh completion scripts.
 
 
+## Linting
+
+`defcommand` is complex and will confuse clj-kondo out of the box, but we provide
+hooks to allow clj-kondo to reasonably lint it.
+
+The hooks are provided with config path `io.github.hlship/cli-tools`.
+
 ## License
 
 `io.github.hlship/cli-tools` is (c) 2022-present Howard M. Lewis Ship.

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  :deps  {org.clojure/clojure      {:mvn/version "1.12.0"}
          org.clojure/tools.cli    {:mvn/version "1.1.230"}
          babashka/process         {:mvn/version "0.5.22"}
-         org.clj-commons/pretty   {:mvn/version "3.3.0"}
+         org.clj-commons/pretty   {:mvn/version "3.3.1"}
          org.clj-commons/humanize {:mvn/version "1.1"}}
 
  :net.lewisship.build/scm

--- a/deps.edn
+++ b/deps.edn
@@ -26,6 +26,13 @@
    :exec-args
    {:patterns [".*-tests?$"]}}
 
+  :1.11
+  {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
+
+  :lint
+  {:deps {clj-kondo/clj-kondo {:mvn/version "2025.01.16"}}
+   :main-opts ["-m" "clj-kondo.main" "--lint" "src"]}
+
   :build
   {:deps       {io.github.hlship/build-tools {:git/tag "0.10.2" :git/sha "3c446e4"}}
    :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -18,9 +18,9 @@
   {:extra-paths ["test" "test-resources"]
    :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1"
                                                        :git/sha "dfb30dd"}
-                 io.github.tonsky/clj-reload {:mvn/version "0.7.1"}
-                 nubank/matcher-combinators {:mvn/version "3.9.1"}
-                 babashka/babashka {:mvn/version "1.12.196"}}
+                 io.github.tonsky/clj-reload          {:mvn/version "0.7.1"}
+                 nubank/matcher-combinators           {:mvn/version "3.9.1"}
+                 babashka/babashka                    {:mvn/version "1.12.196"}}
    :exec-fn     cognitect.test-runner.api/test
    :jvm-opts    ["-Dclj-commons.ansi.enabled=true"]
    :exec-args
@@ -30,8 +30,8 @@
   {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
 
   :lint
-  {:deps {clj-kondo/clj-kondo {:mvn/version "2025.01.16"}}
-   :main-opts ["-m" "clj-kondo.main" "--lint" "src"]}
+  {:deps      {clj-kondo/clj-kondo {:mvn/version "2025.01.16"}}
+   :main-opts ["-m" "clj-kondo.main" "--lint" "src" "test"]}
 
   :build
   {:deps       {io.github.hlship/build-tools {:git/tag "0.10.2" :git/sha "3c446e4"}}

--- a/resources/clj-kondo.exports/io.github.hlship/cli-tools/cli_tools/hooks.clj
+++ b/resources/clj-kondo.exports/io.github.hlship/cli-tools/cli_tools/hooks.clj
@@ -1,0 +1,95 @@
+(ns cli-tools.hooks
+  (:require [clj-kondo.hooks-api :as api]
+            [clojure.pprint :refer [pprint]]))
+
+
+(comment
+  (defcommand foo
+              "docstring"
+              [opta [a...]
+               optb [b...]
+               :let [s1 ...
+                     s2 ...]]
+              ...body)
+  =>
+
+  (defn foo "docstring"
+    [& _args]
+    (let [s1   ...
+          s2   ...
+          opta [a...]
+          obtb [b...]]
+      body)))
+
+(defn- parse
+  [state terms blocks]
+  (if-not (seq terms)
+    blocks
+    (let [[term & more-terms] terms]
+      (if (api/keyword-node? term)
+        (let [{:keys [k]} term]
+          (case k
+            (:in-order :command :summary)
+            (recur state (next more-terms) blocks)
+
+            (:args :options)
+            (recur k more-terms blocks)
+
+            :as
+            (recur state
+                   (next more-terms)
+                   (update blocks :afters conj (first more-terms) (api/token-node 'nil)))
+
+            :let
+            (recur state
+                   (next more-terms)
+                   (update blocks :lets into (-> more-terms first :children)))
+
+            :validate
+            (recur state
+                   (next more-terms)
+                   (update blocks :afters conj (api/token-node (gensym "_validate")) (first more-terms)))))
+        ;; Not a keyword, so either a flag/option or a position argument.
+        (recur state
+               (next more-terms)
+               (update blocks :opts conj term (first more-terms)))))))
+
+
+(defn- parse-interface
+  [interface]
+  #_(pprint {:interface interface})
+  (let [terms  (:children interface)
+        blocks (parse :opts terms {:lets   []
+                                   :opts   []
+                                   :afters []})
+        {:keys [lets opts afters]} blocks
+        vector (api/vector-node
+                 (concat
+                   lets
+                   opts
+                   afters))]
+    vector))
+
+(defn defcommand
+  "Converts defcommand into something parseable. Assumption: the defcommand is valid."
+  [{:keys [node]}]
+  (let [[command-symbol docstring interface & body] (-> node :children rest)
+        interface-vector (parse-interface interface)
+        node'            (api/list-node
+                           [(api/token-node 'defn)
+                            command-symbol
+                            docstring
+                            (api/vector-node [(api/token-node '&)
+                                              (api/token-node '_args)])
+                            (api/list-node
+                              (concat
+                                [(api/token-node 'let)
+                                 interface-vector]
+                                ;; Will this work if more than one expression?
+                                body))])]
+    (println "defcommand input:")
+    (println node)
+    (println "\ndefcommand output:")
+    (println node')
+    (println)
+    {:node node'}))

--- a/resources/clj-kondo.exports/io.github.hlship/cli-tools/config.edn
+++ b/resources/clj-kondo.exports/io.github.hlship/cli-tools/config.edn
@@ -1,2 +1,8 @@
-{:hooks
- {:analyze-call {net.lewisship.cli-tools/defcommand cli-tools.hooks/defcommand}}}
+{:linters
+ {:unresolved-symbol {:exclude [(clojure.test/is [match?])]}}
+ ;; For some reason, clj-kondo triggers :unresolved-symbol and :unresolved-namespace for this NS,
+ ;; maybe because of the use of #?
+ :config-in-ns {net.lewisship.cli-tools.cache {:ignore true}}
+ :hooks
+ {:analyze-call {net.lewisship.cli-tools/defcommand    cli-tools.hooks/defcommand
+                 net.lewisship.cli-tools.impl/cond-let cli-tools.hooks/cond-let}}}

--- a/resources/clj-kondo.exports/io.github.hlship/cli-tools/config.edn
+++ b/resources/clj-kondo.exports/io.github.hlship/cli-tools/config.edn
@@ -1,0 +1,2 @@
+{:hooks
+ {:analyze-call {net.lewisship.cli-tools/defcommand cli-tools.hooks/defcommand}}}

--- a/src/net/lewisship/cli_tools.clj
+++ b/src/net/lewisship/cli_tools.clj
@@ -4,8 +4,7 @@
             [clj-commons.ansi :as ansi]
             [clojure.string :as string]
             [net.lewisship.cli-tools.impl :as impl :refer [cond-let]]
-            [net.lewisship.cli-tools.cache :as cache]
-            [clojure.string :as str]))
+            [net.lewisship.cli-tools.cache :as cache]))
 
 (defn exit
   "An indirect call to System/exit, passing a numeric status code (0 for success, non-zero for
@@ -35,7 +34,7 @@
        [:bold
         tool-name
         (when command-path
-          (list " " (str/join " " command-path)))
+          (list " " (string/join " " command-path)))
         ":"]
        " "
        (map (fn [m]
@@ -103,7 +102,7 @@
   (->> values
        (map name)
        sort
-       (str/join ", ")))
+       (string/join ", ")))
 
 (defmacro defcommand
   "Defines a command.
@@ -250,7 +249,7 @@
                                                                 (str (symbol command-var))
                                                                 (str "namespace " (name (get-in conflict [:group-category :category]))))]
                                               (throw (RuntimeException. (format "command %s defined by %s conflicts with %s"
-                                                                                (str/join " " command-path)
+                                                                                (string/join " " command-path)
                                                                                 (str (symbol v))
                                                                                 where))))
                                             :else

--- a/src/net/lewisship/cli_tools/completions.clj
+++ b/src/net/lewisship/cli_tools/completions.clj
@@ -3,7 +3,6 @@
   {:command-ns 'net.lewisship.cli-tools.builtins}
   (:require [babashka.fs :as fs]
             [clojure.java.io :as io]
-            [clojure.string :as s]
             [net.lewisship.cli-tools :refer [defcommand abort]]
             [clojure.string :as string]
             selmer.util

--- a/src/net/lewisship/cli_tools/impl.clj
+++ b/src/net/lewisship/cli_tools/impl.clj
@@ -1,7 +1,6 @@
 (ns ^:no-doc net.lewisship.cli-tools.impl
   "Private namespace for implementation details for new.lewisship.cli-tools, subject to change."
   (:require [clojure.string :as string]
-            [clojure.string :as str]
             [clj-commons.ansi :refer [compose pout perr *color-enabled*]]
             [clojure.tools.cli :as cli]
             [clj-commons.humanize :as h]
@@ -108,14 +107,6 @@
   [s]
   (binding [*out* *err*] (println s)))
 
-(defn- print-errors
-  [errors]
-  (when (seq errors)
-    (println)
-    (pout [:red (if (= 1 (count errors)) "Error:" "Errors:")])
-    (doseq [e errors]
-      (pout "  " [:red e]))))
-
 (defn- arg-spec->str
   [arg-spec]
   (let [{:keys [label optional repeatable]} arg-spec]
@@ -129,16 +120,16 @@
 (defn- first-sentence
   [s]
   (-> s
-      str/trim
-      str/split-lines
+      string/trim
+      string/split-lines
       first
-      (str/split #"\s*\.")
+      (string/split #"\s*\.")
       first
-      str/trim))
+      string/trim))
 
 (defn- indentation-of-line
   [line]
-  (if (str/blank? line)
+  (if (string/blank? line)
     [0 ""]
     (let [[_ indent text] (re-matches #"(\s+)(.*)" line)]
       (if
@@ -155,9 +146,9 @@
 
 (defn- cleanup-docstring
   [docstring]
-  (let [docstring'       (str/trim docstring)
+  (let [docstring'       (string/trim docstring)
         lines            (->> docstring'
-                              str/split-lines
+                              string/split-lines
                               (map indentation-of-line))
         non-zero-indents (->> lines
                               (map first)
@@ -167,7 +158,7 @@
       (let [indentation (reduce min non-zero-indents)]
         (->> lines
              (mapv #(strip-indent indentation %))
-             (str/join "\n"))))))
+             (string/join "\n"))))))
 
 (defn print-summary
   [command-map]
@@ -184,7 +175,7 @@
         ;; A stand-alone tool will use its command-name, a command within
         ;; a multi-command tool will have a command-path.
         [:bold.green (if command-path
-                       (str/join " " command-path)
+                       (string/join " " command-path)
                        command-name)]
         " [OPTIONS]"
         (map list (repeat " ") arg-strs))
@@ -225,7 +216,7 @@
         (when tool-name " ")
 
         (if command-path
-          (str/join " " command-path)
+          (string/join " " command-path)
           command-name)]
        ":"
        (if (= 1 (count errors))
@@ -328,7 +319,7 @@
           (println-err (format "Warning: command %s, argument %s contains invalid key(s): %s"
                                command-name
                                id
-                               (str/join ", " invalid-keys))))
+                               (string/join ", " invalid-keys))))
         {:label      label
          :id         id
          :doc        doc
@@ -761,7 +752,7 @@
             all-commands       (cond->> (reduce into [] (vals grouped-commands))
                                         ;; For a flat view, each command's name is its path (i.e., prefixed with the command group).
                                         flat (map (fn [command]
-                                                    (assoc command :command-name (str/join " " (:command-path command))))))
+                                                    (assoc command :command-name (string/join " " (:command-path command))))))
             command-name-width (->> all-commands
                                     (map :command-name)
                                     (map count)
@@ -795,7 +786,7 @@
 
 (defn- to-matcher
   [s]
-  (let [terms      (str/split s #"\-")
+  (let [terms      (string/split s #"\-")
         re-pattern (apply str "(?i)"
                           (map-indexed (fn [i term]
                                          (str
@@ -828,7 +819,7 @@
   [tool-name arguments commands]
   (let [command-name (first arguments)]
     (if (or (nil? command-name)
-            (str/starts-with? command-name "-"))
+            (string/starts-with? command-name "-"))
       (abort [:bold tool-name] ": no command provided" (use-help-message tool-name))
       (loop [prefix            []
              term              command-name
@@ -839,9 +830,9 @@
 
           ;; Options start with a '-', but we're still looking for commands
           (or (nil? term)
-              (str/starts-with? term "-"))
+              (string/starts-with? term "-"))
           (abort
-            [:bold.green tool-name ": " [:red (str/join " " prefix)]]
+            [:bold.green tool-name ": " [:red (string/join " " prefix)]]
             " is incomplete; "
             (compose-list matchable-terms)
             " could follow; use "
@@ -908,7 +899,7 @@
   [{:keys [tool-name commands arguments] :as options}]
   ;; Capture these options for use by help command or when printing usage
   (binding [*options* options]
-    (when (str/blank? tool-name)
+    (when (string/blank? tool-name)
       (throw (ex-info "must specify :tool-name" {:options options})))
     (dispatch-options-parser tool-name arguments commands)
     nil))

--- a/src/net/lewisship/cli_tools/job_status_demo.clj
+++ b/src/net/lewisship/cli_tools/job_status_demo.clj
@@ -1,6 +1,6 @@
 (ns net.lewisship.cli-tools.job-status-demo
   {:command-ns 'net.lewisship.cli-tools.builtins}
-  (:require [net.lewisship.cli-tools :refer [defcommand] :as c]
+  (:require [net.lewisship.cli-tools :refer [defcommand]]
             [net.lewisship.cli-tools.job-status :as j]))
 
 (defn sleep

--- a/test/net/lewisship/cli_tools/impl_test.clj
+++ b/test/net/lewisship/cli_tools/impl_test.clj
@@ -1,8 +1,7 @@
 (ns net.lewisship.cli-tools.impl-test
   (:require [clojure.test :refer [deftest is are use-fixtures]]
             [clj-commons.ansi :as ansi]
-            [net.lewisship.cli-tools.impl :refer [compile-interface]]
-            [net.lewisship.cli-tools.impl :as impl]))
+            [net.lewisship.cli-tools.impl :as impl :refer [compile-interface]]))
 
 ;; Disable ANSI color output during tests.
 (use-fixtures :once

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -8,8 +8,7 @@
             net.lewisship.conflict
             matcher-combinators.clj-test                    ;; to enable (is (match? ..))
             [net.lewisship.cli-tools.impl :as impl]
-            [clojure.repl :as repl]
-            [clojure.string :as str])
+            [clojure.repl :as repl])
   (:import
     (java.io BufferedReader StringReader StringWriter)))
 
@@ -150,14 +149,14 @@
   [foo [nil "--foo FOO" "Foo option" :default "abc"]
    bar [nil "--bar BAR" "Bar option" :default-fn (constantly "xyz")]
    bazz [nil "--bazz BAZZ" "Bazz option" :default :bazz :default-desc "Bazzy"]]
-  nil)
+  [foo bar bazz])
 
 (deftest option-defaults
   (is (= (slurp "test-resources/option-defaults.txt")
          (with-exit 0 (invoke-command "default-variants" "-h")))))
 
 (defcommand in-order
-  ""
+  "Test of :in-order option"
   [verbose ["-v" "--verbose"]
    :args
    command ["COMMAND" "Remote command to execute"]
@@ -167,10 +166,13 @@
    :in-order true
    :summary "Execute remote command"]
   {:command command
-   :args    args})
+   :args    args
+   :verbose verbose})
 
 (deftest in-order-arguments
-  (is (= {:command "ls", :args ["-lR"]}
+  (is (= {:command "ls"
+          :args    ["-lR"]
+          :verbose true}
          ;; Without :in-order true, the -lR is flagged as an error
          (in-order "-v" "ls" "-lR"))))
 
@@ -208,7 +210,7 @@
                                :namespaces '[net.lewisship.example-ns]
                                :arguments  ["help" "EXP"]})))))
 
-(deftest help-with-search-term
+(deftest help-with-search-term-no-match
   (is (= (slurp "test-resources/tool-help-search-no-match.txt")
          (with-exit 0
                     (dispatch {:tool-name  "test-harness"
@@ -217,7 +219,7 @@
 
 (deftest use-of-command-ns-meta
   (is (= (slurp "test-resources/combo-help.txt")
-         (  with-exit 0
+         (with-exit 0
                     (dispatch {:tool-name  "combo"
                                :namespaces '[net.lewisship.cli-tools.colors]
                                :arguments  ["-h"]})))))
@@ -228,7 +230,7 @@
          :parse-fn keyword
          :validate [allowed-modes (str "Must be one of " mode-names)]]
    :let [allowed-modes #{:batch :async :real-time}
-         mode-names (->> allowed-modes (map name) sort (str/join ", "))]]
+         mode-names (->> allowed-modes (map name) sort (string/join ", "))]]
   {:mode mode})
 
 
@@ -299,8 +301,8 @@
          (cli/sorted-name-list [:whiskey :tango :foxtrot]))))
 
 (deftest group-namespace
-  (let [group-ns   (find-ns 'net.lewisship.group-ns)
-        builtin-ns (find-ns 'net.lewisship.cli-tools.builtins)]
+  (let [_group-ns   (find-ns 'net.lewisship.group-ns)
+        _builtin-ns (find-ns 'net.lewisship.cli-tools.builtins)]
     (is (= '[[{:category      net.lewisship.group-ns
                :command-group "group"
                :label         "Grouped commands"


### PR DESCRIPTION
Add clj-kondo configuration to build, address linter issues identified, and include clj-kondo exports for downstream users.