### PR TITLE
Defeat clj-kondo's static type analysis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ The `abort` function assumes an exit status of 1 if the first message passed is 
 It also now prints the tool and command name in bold green (to be conistent with
 the rest of the library).
 
+The clj-kondo hook for the `defcommand` produces slightly different code, that defeats
+the clj-kondo static type analysis, preventing spurious warnings about vectors passed
+to particular clojure.core functions.
+
 Dependencies were not properly declared for Clojure applications that use cli-tools
 (libraries that are bundled with Babashka were omitted).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ The `abort` function assumes an exit status of 1 if the first message passed is 
 It also now prints the tool and command name in bold green (to be conistent with
 the rest of the library).
 
-The clj-kondo hook for the `defcommand` produces slightly different code, that defeats
+The clj-kondo hook for the `defcommand` now produces slightly different code, that defeats
 the clj-kondo static type analysis, preventing spurious warnings about vectors passed
 to particular clojure.core functions.
 

--- a/resources/clj-kondo.exports/io.github.hlship/cli-tools/cli_tools/hooks.clj
+++ b/resources/clj-kondo.exports/io.github.hlship/cli-tools/cli_tools/hooks.clj
@@ -34,6 +34,23 @@
                (next more-terms)
                (update blocks :opts conj term (first more-terms)))))))
 
+(defn xform-opts
+  "This is a lot of work to actually defeat clj-kondo's normal static analysis.
+
+  See https://github.com/hlship/cli-tools/issues/28 for more info."
+  [opts]
+  (when (seq opts)
+    (let [pairs     (partition 2 opts)
+          collector (api/token-node (gensym "options"))
+          map-terms (mapcat (fn [[sym v]]
+                              [(api/keyword-node (-> sym str keyword)) v])
+                            pairs)]
+      [collector
+       (api/map-node (vec map-terms))
+
+       (api/map-node [(api/keyword-node :keys)
+                      (api/vector-node (map first pairs))])
+       collector])))
 
 (defn- parse-interface
   [interface]
@@ -45,7 +62,7 @@
         vector (api/vector-node
                  (concat
                    lets
-                   opts
+                   (xform-opts opts)
                    afters))]
     vector))
 


### PR DESCRIPTION
The clj-kondo hook for the `defcommand` now produces slightly different code, that defeats
the clj-kondo static type analysis, preventing spurious warnings about vectors passed
to particular clojure.core functions.

Fixes #28