### PR TITLE
Slight tweak to text and formatting when suggesting help

### DIFF
--- a/src/net/lewisship/cli_tools/impl.clj
+++ b/src/net/lewisship/cli_tools/impl.clj
@@ -25,17 +25,20 @@
 
 (def ^:private supported-keywords #{:in-order :args :options :command :title :let :validate})
 
+(defn- compose-command-path
+  [tool-name command-path]
+  (when tool-name
+    [:bold.green
+     tool-name
+     (when (seq command-path)
+       (list
+         " "
+         (string/join " " command-path)))]))
+
 (defn command-path
   []
-  (let [{:keys [tool-name]} *tool-options*
-        path (:command-path *command-map*)]
-    (when tool-name
-      [:bold.green
-       tool-name
-       (when (seq path)
-         (list
-           " "
-           (string/join " " path)))])))
+  (compose-command-path (:tool-name *tool-options*)
+                        (:command-path *command-map*)))
 
 (defn exit
   [status]
@@ -845,6 +848,10 @@
   [tool-name]
   (abort [:bold.green tool-name] ": no command provided" (use-help-message tool-name)))
 
+(def ^:private help
+  (list
+    [:bold.green "--help"] " (or " [:bold.green "-h"] ")"))
+
 (defn- incomplete
   [tool-name command-path matchable-terms]
   (abort
@@ -855,7 +862,9 @@
     " is incomplete; "
     (compose-list matchable-terms)
     " could follow; use "
-    [:bold [:green tool-name " " (string/join " " command-path) " --help (or -h)"]]
+    (compose-command-path tool-name command-path)
+    " "
+    help
     " to list commands"))
 
 (defn- no-match
@@ -867,12 +876,9 @@
                             (compose-list matchable-terms)))
         help-suffix (list
                       "; use "
-                      [:bold [:green tool-name " "
-                              (if (seq command-path)
-                                (string/join " " command-path)
-                                "help")]]
-                      (when (seq command-path)
-                        " --help (or -h)")
+                      (compose-command-path tool-name command-path)
+                      " "
+                      help
                       " to list commands")]
     (abort
       [:bold [:green tool-name] ": "
@@ -1055,4 +1061,3 @@
                             transformer (transformer dispatch-options))]
     {:tool-name tool-name'
      :command-root root'}))
-

--- a/test-resources/help-incomplete-nested.txt
+++ b/test-resources/help-incomplete-nested.txt
@@ -1,1 +1,1 @@
-[0;32;1mgroup-test: group [0;31;1mnested[m is incomplete; [0;32;1mbutterfly[m or [0;32;1mleaf[m could follow; use [0;32;1mgroup-test group nested --help (or -h)[m to list commands
+[0;32;1mgroup-test: group [0;31;1mnested[m is incomplete; [0;32;1mbutterfly[m or [0;32;1mleaf[m could follow; use [0;32;1mgroup-test group nested[m [0;32;1m--help[m (or [0;32;1m-h[m) to list commands

--- a/test-resources/help-incomplete.txt
+++ b/test-resources/help-incomplete.txt
@@ -1,1 +1,1 @@
-[0;32;1mgroup-test: [0;31;1mgroup[m is incomplete; [0;32;1mecho[m, [0;32;1medit[m, or [0;32;1mnested[m could follow; use [0;32;1mgroup-test group --help (or -h)[m to list commands
+[0;32;1mgroup-test: [0;31;1mgroup[m is incomplete; [0;32;1mecho[m, [0;32;1medit[m, or [0;32;1mnested[m could follow; use [0;32;1mgroup-test group[m [0;32;1m--help[m (or [0;32;1m-h[m) to list commands

--- a/test/net/lewisship/cli_tools/impl_test.clj
+++ b/test/net/lewisship/cli_tools/impl_test.clj
@@ -139,7 +139,7 @@
                       :command-root {"help" {:fn ::placeholder}}
                       :arguments    ["no-such-command"]})
 
-      (is (= "bravo: no-such-command is not a command, expected help; use bravo help to list commands"
+      (is (= "bravo: no-such-command is not a command, expected help; use bravo --help (or -h) to list commands"
              @*message*)))))
 
 (deftest compose-list-tests

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -356,6 +356,10 @@
        :out
        (spit "test-resources/tool-help-grouped.txt"))
 
+  (->> (exec-group "gr")
+       :err
+       (spit "test-resources/help-incomplete.txt"))
+
   )
 
 (deftest can-find-a-grouped-command
@@ -382,7 +386,7 @@
     (is (match? {:err "group-test: group e could match echo or edit; use group-test group --help (or -h) to list commands\n"}
                 (exec-group "g" "e" "multiple")))
 
-    (is (match? {:err "group-test: echo is not a command, expected default, explicit, group (or one other); use group-test help to list commands\n"}
+    (is (match? {:err "group-test: echo is not a command, expected default, explicit, group (or one other); use group-test --help (or -h) to list commands\n"}
                 (exec-group "echo" "wrong-level")))))
 
 (deftest select-option-no-default


### PR DESCRIPTION
The option (--help or -h) is now in bold green, like the commands