### PR TITLE
feat: add optional :version key to dispatch-options 

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -24,9 +24,9 @@ jobs:
           distribution: 'corretto'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@13.5.2
+        uses: DeLaGuardo/setup-clojure@13.6.0
         with:
-          cli: 1.12.4.1602
+          cli: 1.12.4.1629
 
       - name: Cache clojure dependencies
         uses: actions/cache@v5

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src"
          "resources"]
 
- :deps  {org.clj-commons/pretty   {:mvn/version "3.6.8"}
-         org.clj-commons/humanize {:mvn/version "1.1"}}
+ :deps  {org.clj-commons/pretty   {:mvn/version "3.8.0"}
+         org.clj-commons/humanize {:mvn/version "1.2"}}
 
  :net.lewisship.build/scm
  {:url     "https://github.com/hlship/cli-tools"
@@ -17,15 +17,15 @@
                  io.github.hlship/trace               {:mvn/version "1.4"}
                  io.github.tonsky/clj-reload          {:mvn/version "1.0.0"}
                  nubank/matcher-combinators           {:mvn/version "3.10.0"}
-                 babashka/babashka                    {:mvn/version "1.12.215"}}
+                 babashka/babashka                    {:mvn/version "1.12.218"}}
    :exec-fn     cognitect.test-runner.api/test
    :jvm-opts    ["-Dclj-commons.ansi.enabled=true"]
    :exec-args
    {:patterns [".*-tests?$"]}}
 
   :pom
-  {:extra-deps {org.clojure/tools.cli {:mvn/version "1.3.250" :optional true}
-                babashka/fs           {:mvn/version "0.5.31" :optional true}
+  {:extra-deps {org.clojure/tools.cli {:mvn/version "1.4.256" :optional true}
+                babashka/fs           {:mvn/version "0.5.33" :optional true}
                 babashka/process      {:mvn/version "0.6.25" :optional true}
                 selmer/selmer         {:mvn/version "1.13.1" :optional true}
                 org.babashka/cli      {:mvn/version "0.8.67" :optional true}}}
@@ -34,7 +34,7 @@
   {:override-deps {org.clojure/clojure ^:antq/exclude {:mvn/version "1.11.4"}}}
 
   :lint
-  {:deps      {clj-kondo/clj-kondo {:mvn/version "2026.01.19"}}
+  {:deps      {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}
    :main-opts ["-m" "clj-kondo.main" "--lint" "src" "test"]}
 
   :build

--- a/doc/dispatch.md
+++ b/doc/dispatch.md
@@ -19,6 +19,7 @@ are ultimately exposed as local symbols that your command's code can act on.
 (dispatch 
   {:namespaces [...]
    :doc "String that defines the tool, used in tool-level help."
+   :version "1.0.0"  ;; optional; adds --version / -V tool option
    :groups {"my-group" {:title "One line title describing the group."
                         :doc "Longer description of the group, used in group-level help."
                         :namespaces [...]

--- a/src/net/lewisship/cli_tools.clj
+++ b/src/net/lewisship/cli_tools.clj
@@ -250,6 +250,7 @@
 
   - :tool-name (optional, string) - used in command summary and errors
   - :doc (optional, string) - used in help summary
+  - :version (optional, string) - if present, adds --version / -V tool option that prints the version and exits
   - :arguments - command line arguments to parse (defaults to `*command-line-args*`)
   - :namespaces - seq of symbols identifying namespaces to search for root-level commands
   - :groups - map of group command (a string) to a group map
@@ -295,8 +296,10 @@
   (let [merged-options    (merge {:arguments *command-line-args*}
                                  (default-dispatch-options)
                                  dispatch-options)
-        {:keys [extra-tool-options tool-options-handler]} merged-options
-        full-options      (concat extra-tool-options impl/default-tool-options)
+        {:keys [extra-tool-options tool-options-handler version]} merged-options
+        version-option    (when version
+                            [["-V" "--version" "Display version"]])
+        full-options      (concat extra-tool-options version-option impl/default-tool-options)
         {:keys [options arguments summary errors]}
         (cli/parse-opts (:arguments merged-options)
                         full-options
@@ -319,6 +322,10 @@
                      (when (seq errors)
                        (print-errors errors)
                        (exit 1))
+
+                     (when (:version options)
+                       (println version)
+                       (exit 0))
 
                      (if tool-options-handler
                        (tool-options-handler options dispatch-options' callback)

--- a/src/net/lewisship/cli_tools/specs.clj
+++ b/src/net/lewisship/cli_tools/specs.clj
@@ -9,6 +9,7 @@
                                            ::doc
                                            ::arguments
                                            ::groups
+                                           ::version
                                            ::transformer
                                            ::tool-options-handler
                                            ::extra-tool-options
@@ -40,6 +41,8 @@
 (s/def ::extra-tool-options vector?)
 
 (s/def ::tool-options-handler fn?)
+
+(s/def ::version ::non-blank-string)
 
 (s/def ::pre-dispatch fn?)
 

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -132,6 +132,35 @@
               (binding [ansi/*color-enabled* false]
                 (invoke-command "--unknown")))))
 
+(defn invoke-with-version
+  [& args]
+  (dispatch-with-result {:tool-name  "harness"
+                         :namespaces ['net.lewisship.cli-tools-test]
+                         :version    "1.2.3"
+                         :arguments  args}))
+
+(deftest version-long-flag
+  (is (match? {:status    0
+               :out-lines ["1.2.3"]}
+              (invoke-with-version "--version"))))
+
+(deftest version-short-flag
+  (is (match? {:status    0
+               :out-lines ["1.2.3"]}
+              (invoke-with-version "-V"))))
+
+(deftest version-takes-precedence-over-other-args
+  (is (match? {:status    0
+               :out-lines ["1.2.3"]}
+              (invoke-with-version "--version" "configure" "--host" "example.com"))))
+
+(deftest version-flag-unknown-without-version-key
+  (is (match? {:status 1
+               :err-lines
+               ["Error in harness: Unknown option: \"--version\""]}
+              (binding [ansi/*color-enabled* false]
+                (invoke-command "--version")))))
+
 (deftest standard-help
   (is (match? {:status 0
                :out    (slurp "test-resources/help.txt")}


### PR DESCRIPTION
When :version is provided, a --version / -V tool option is added.
It prints the version to `*out*`and exits 0, regardless of other args.

🤖 Generated with [eca](https://eca.dev)

Co-Authored-By: eca-agent <git@eca.dev>
