### PR TITLE
feat: add :pass-through command interface option 

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@13.6.0
         with:
-          cli: 1.12.4.1629
+          cli: 1.12.5.1645
 
       - name: Cache clojure dependencies
         uses: actions/cache@v5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 *BREAKING CHANGES*
 
+* JDK 17 is now required when using Clojure
 * Groups are now defined in the options passed to `net.lewisship.cli-tools/dispatch`, not in
   namespace metadata
 * Command names are matched as prefixes (not substrings)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,26 +17,28 @@
     * `expand-dispatch-options` has been removed
 * When an arg is ambiguous during dispatch, the error text now says "could match" and uses "or" as the conjunction, e.g. "ex could match exhume or extract"
 * Tool and command help is now printed to \*out\*, not \*err*\*
-* The builtin `help` command now as an option, `-c` / `--commands`, that can be one of `none`, `root`, or `all`, and the `--flat` switch was removed.
+* The builtin `help` command now as an option, `-c` / `--commands`, that can be one of `none`, `root`, or `all`, and the `--flat` switch was removed
 * Dependencies no longer include those provided by Babashka itself, reverting the change in 0.15.1; new documentation identifies what to add back in
+* The :in-order key in a command interface results in parsing with option `:subcommand :implicit`; previously it was
+  (equivalent to) `:subcommand :explicit`.
   
 *Changes*
 
 * Groups may now be nested, to arbitrary depth
 * You may now enter `-h` or `--help` after a group to get help for just that group
 * Tool help output has been reordered, with top-level tool commands first (previously, those were in a "Builtin" group and listed last)
-* Tool help now displays just root-level commands by default (add `--commands all` to list nested commands)
+* Tool help now displays just root-level commands and groups by default (add `--commands all` to list nested commands)
 * When extracting the first sentence as the single-line title, embedded periods are no longer considered the end of the sentence
 * `net.lewisship.cli-tools`:
     * Added function `tool-name`
     * Added function `command-root`
     * Added function `read-password`
-    * New `command-path` function returns a composed string of the tool name and command path
+    * New `command-path` function returns a composed string of the tool name and command path (useful for error messages)
     * `dispatch` function has new options:
         * :extra-tool-options - vector of additional tool options to prefix the default
         * :tool-options-handler - callback function for handling extra tool options
-        * :transformer provides a function to add additional commands and groups after namespaces are loaded
-        * :source-dirs specifies extra directories to consider when caching
+        * :transformer - a function to add additional commands and groups after namespaces are loaded
+        * :source-dirs - specifies extra directories to consider when caching
         * :pre-dispatch - callback function invoked before dispatch
         * :pre-invoke - callback function invoked before the dispatched command function is invoked 
         * Can now handle the case where a command has the same name as a group
@@ -45,6 +47,7 @@
 * Added `net.lewisship.cli-tools.test` namespace
 * Added `net.lewisship.cli-tools.styles` namespace
 * When a :version dispatch option is provided, a `--version` (or `-V`) tool option is added that prints the version and exits
+* Command interface option :in-order has been deprecated and replaced with :pass-through
 
 [Closed Issues](https://github.com/hlship/cli-tools/milestone/9?closed=1)
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Documentation starts with [the overview](doc/overview.md).
 ## Compatibility
 
 `cli-tools` is compatible with Clojure 1.11 and above, and w/ Babashka.  
+For Clojure, it requires JDK 17 or above.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for you.
 - A simple tool simply parses its command line arguments and executes some code using those arguments (think: `ls` or `cat`)
 - A common tool is composed of multiple commands, across multiple namespaces. The first command line argument
   will select the specific sub-command to execute. (think: `git`)
-- A complex tool organizes some commands into command groups that share an initial name (think `kubectl`)
+- A complex tool organizes some commands into command groups that share an initial name (think: `kubectl`)
 
 For tools with multiple commands, `cli-tools` automatically adds 
 a built-in `help` command to list out what commands are available, and

--- a/doc/defcommand.md
+++ b/doc/defcommand.md
@@ -125,7 +125,7 @@ Normally, the command title (which appears next to the command in the `help` too
 the first sentence of the command's docstring, up to the first `.`.  If, for some reason,
 that default is incorrect, the command's summary can be explicitly specified using `:title`.
 
-### :in-order true
+### :pass-through true
 
 By default, options are parsed using `clojure.tools.cli/parse-opts`, with the `:in-order` option set to false;
 this means that `parse-opts` will stop at the first
@@ -149,10 +149,12 @@ with an error that `-lR is not recognized`.
 You can always use `--` to split options from arguments, so `app-admin remote -- ls -lR` will work,
 but is clumsy.
 
-Instead, add `:in-order true` to the end of the interface, and any
+Instead, add `:pass-through true` to the end of the interface, and any
 unrecognized options will be parsed as positional arguments instead,
 so `app-admin remote ls -lR` will work, and `-lR` will be provided as a string in the `remote-args`
 seq.
+
+For backwards compatibility, you may also specify `:in-order true` to accomplish the same thing.
 
 ### :let \<bindings\>
 

--- a/resources/clj-kondo.exports/io.github.hlship/cli-tools/cli_tools/hooks.clj
+++ b/resources/clj-kondo.exports/io.github.hlship/cli-tools/cli_tools/hooks.clj
@@ -9,7 +9,7 @@
       (if (api/keyword-node? term)
         (let [{:keys [k]} term]
           (case k
-            (:in-order :command :title)
+            (:in-order :command :title :pass-through)
             (recur state (next more-terms) blocks)
 
             (:args :options)

--- a/src/net/lewisship/cli_tools.clj
+++ b/src/net/lewisship/cli_tools.clj
@@ -303,7 +303,7 @@
         {:keys [options arguments summary errors]}
         (cli/parse-opts (:arguments merged-options)
                         full-options
-                        :in-order true
+                        :subcommand :explicit
                         :summary-fn summarize-specs)
         {:keys [color no-color help]} options
         color-flag        (cond color true

--- a/src/net/lewisship/cli_tools/cache.cljc
+++ b/src/net/lewisship/cli_tools/cache.cljc
@@ -9,6 +9,7 @@
             [clj-commons.ansi :refer [perr]]
             #?(:bb [babashka.classpath :as cp]))
   (:import (java.io File)
+           (java.util HexFormat)
            (java.nio ByteBuffer)
            (java.security MessageDigest)))
 
@@ -58,10 +59,10 @@
       ;; Adding or removing a file (even if no other files are touched) will change the digest.
       (update-digest-recursively digest f))))
 
-(defn- hex-string [^bytes input]
-  (let [sb (StringBuilder.)]
-    (run! #(.append sb (format "%X" %)) input)
-    (str sb)))
+(defn- hex-string 
+  [^bytes input]
+  (-> (HexFormat/of)
+      (.formatHex input)))
 
 (defn classpath-digest
   "Passed the tool options, return a hex string of the SHA-1 digest of the files from the classpath and

--- a/src/net/lewisship/cli_tools/impl.clj
+++ b/src/net/lewisship/cli_tools/impl.clj
@@ -24,7 +24,7 @@
   command spec. Used when extracting options for completions."
   false)
 
-(def ^:private supported-keywords #{:in-order :args :options :command :title :let :validate})
+(def ^:private supported-keywords #{:in-order :pass-through :args :options :command :title :let :validate})
 
 (defn- compose-command-path
   [tool-name command-path]
@@ -577,14 +577,23 @@
   (assoc state :consuming :keyword
          :pending false))
 
+(defn- consume-boolean
+  [state k option-key form]
+  (when-not (boolean? form)
+    (fail (str "Expected boolean after " k) state form))
+  (-> state
+      (assoc-in [:parse-opts-options option-key] form)
+      complete-keyword))
+
+;; :in-order is the deprecated name for :pass-through
+
 (defmethod consumer :in-order
   [state form]
-  (when-not (boolean? form)
-    (fail "Expected boolean after :in-order" state form))
+  (consume-boolean state :in-order :pass-through form))
 
-  (-> state
-      (assoc-in [:parse-opts-options :in-order] form)
-      complete-keyword))
+(defmethod consumer :pass-through
+  [state form]
+  (consume-boolean state :pass-through :pass-through form))
 
 (defmethod consumer :let
   [state form]
@@ -653,15 +662,17 @@
   [command-name command-doc command-line-arguments command-spec]
   (cond-let
    :let [{:keys [command-args command-options parse-opts-options]} command-spec
-         {:keys [in-order]
-          :or {in-order false}} parse-opts-options
+         {:keys [pass-through]
+          :or {pass-through false}} parse-opts-options
          positional-specs (compile-positional-specs command-name command-args)
+         extra-cli-opts (cond-> []
+                          pass-through (conj :subcommand :implicit))
          command-map (merge command-spec
                             {:command-name command-name
                              :positional-specs positional-specs}
-                            (cli/parse-opts command-line-arguments command-options
-                                            :in-order in-order
-                                            :summary-fn summarize-specs))
+                            (apply cli/parse-opts command-line-arguments command-options
+                                            :summary-fn summarize-specs
+                                            extra-cli-opts))
          {:keys [arguments options]} command-map]
 
     ;; Check for help first, as otherwise can get needless errors r.e. missing required positional arguments.

--- a/test-resources/help-with-color-enabled.txt
+++ b/test-resources/help-with-color-enabled.txt
@@ -11,6 +11,7 @@ Commands:
   [0;32;1mdefault-variants[m: Different option defaults
               [0;32;1mhelp[m: List available commands
           [0;32;1min-order[m: Execute remote command
+         [0;32;1mpass-thru[m: For testing :pass-through option
           [0;32;1mset-mode[m: Sets the execution mode
          [0;32;1mtool-info[m: Echoes the tool name and root command map keys
           [0;32;1mvalidate[m: validate command

--- a/test-resources/help-with-no-color.txt
+++ b/test-resources/help-with-no-color.txt
@@ -11,6 +11,7 @@ Commands:
   default-variants: Different option defaults
               help: List available commands
           in-order: Execute remote command
+         pass-thru: For testing :pass-through option
           set-mode: Sets the execution mode
          tool-info: Echoes the tool name and root command map keys
           validate: validate command

--- a/test/net/lewisship/cli_tools/impl_test.clj
+++ b/test/net/lewisship/cli_tools/impl_test.clj
@@ -105,8 +105,12 @@
     (is (= "Unexpected keyword" (ex-message e)))))
 
 (deftest in-order-option
-  (is (= {:in-order true}
+  (is (= {:pass-through true}
          (:parse-opts-options (compile-interface '[:in-order true])))))
+
+(deftest pass-thru-option
+  (is (= {:pass-through true}
+         (:parse-opts-options (compile-interface '[:pass-through true])))))
 
 (deftest in-order-must-be-boolean
   (when-let [e (is (thrown? Exception

--- a/test/net/lewisship/cli_tools_test.clj
+++ b/test/net/lewisship/cli_tools_test.clj
@@ -22,7 +22,7 @@
 
 #_{:clj-kondo/ignore [:unused-private-var]}
 (defn- capture
-  "Used when output changes to capture new output (the embedded ANSI sequences are hard to work with."
+  "Used when output changes to capture new output (the embedded ANSI sequences are hard to work with)."
   ([file result]
    (capture file :out result))
   ([file k result]
@@ -52,6 +52,14 @@
                             (assoc m k v))
                :repeatable true]]
   {:verbose verbose :host host :key-values key-values})
+
+(defcommand pass-thru
+  "For testing :pass-through option."
+  [:pass-through true
+   :args
+   args ["ARGS" "Pass thru args"
+         :repeatable true]]
+   (-> args vec prn))
 
 
 (defcommand collect
@@ -121,7 +129,7 @@
 (deftest tool-options-access
   (is (match? {:status    0
                :out-lines ["Tool name: harness"
-                           "Commands: collect, configure, default-variants, help, in-order, set-mode, tool-info, validate"]}
+                           "Commands: collect, configure, default-variants, help, in-order, pass-thru, set-mode, tool-info, validate"]}
               (invoke-command "tool-info"))))
 
 (deftest unknown-tool-option
@@ -196,6 +204,11 @@
   (is (match? {:status 1
                :err    (slurp "test-resources/excess-values.txt")}
               (invoke-command "collect" "the-key" "the-value" "the-extra"))))
+
+(deftest extra-options-with-in-order
+  (is (match? {:status 0
+               :out "[\"--foo\" \"--bar\" \"baz\"]\n"}
+              (invoke-command "pass-thru" "--foo" "--bar" "baz"))))
 
 
 (defcommand default-variants


### PR DESCRIPTION
Previously, one could use :in-order true to consume extra arguments into
a repeatable positional argument, but that would fail if the first such
argument looked like an option (a leading dash) and would require the user to
add a `--` divider. clojure.tools.cli recently added :subcommand :implicit to address
this, and :pass-through sets up that option.

:in-order is still supported, as a deprecated alias for :pass-through.